### PR TITLE
Update Go version in Github workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,10 +15,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Go 1.21
+      - name: Setup Go 1.22
         uses: actions/setup-go@v2
         with:
-          go-version: 1.21
+          go-version: 1.22
 
       - name: Generate Test Coverage
         run: go test ./... -coverprofile=./cover.out


### PR DESCRIPTION
The Go version used in the Github workflow coverage.yml file has been updated. Specifically, the version is changed from 1.21 to 1.22. This change keeps our Go environment up-to-date with the latest stable release.